### PR TITLE
Fix image fit for non-square images

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,4 +2,5 @@
   flex: 0 0 36px;
   margin-right: 5px;
   margin-bottom: 3px;
+  object-fit: cover;
 }


### PR DESCRIPTION
- FoundryVTT version: 0.6.1
- Issue: Non-square images are squeezed
- Fix: `object-fit: cover;` allows images to retain both the box size and the image dimensions.