### PR TITLE
Fix: no token img if no token selected

### DIFF
--- a/src/scripts/chat-portrait.ts
+++ b/src/scripts/chat-portrait.ts
@@ -79,7 +79,7 @@ class ChatPortrait {
         if (!actor && forceNameSearch) {
             actor = game.actors.find((a: Actor) => a.name === speaker.alias);
         }
-        return useTokenImage ? actor?.token?.data?.img : actor?.img;
+        return useTokenImage ? actor?.data?.token?.img : actor?.img;
     }
 
     /**


### PR DESCRIPTION
If the "Use Token Image" configuration was set but someone made a roll or talked without having a token selected, the script would look into the actor data for the token img for that actor. The path it was taking to get there was wrong. Its now fixed.