### PR TITLE
Fix ::before style element for player names in the generic style set

### DIFF
--- a/src/styles/chat-portrait-style-generic.css
+++ b/src/styles/chat-portrait-style-generic.css
@@ -59,7 +59,7 @@
   opacity: 0.5;
 }
 
-.chat-portrait-playerName::before {
+.chat-portrait-playerName-generic::before {
   content: ' [';
 }
 


### PR DESCRIPTION
The generic style set has a typo'd "::before" style element for the player name, leading to unsightly "CharacterPlayer]" instead of "Character[Player]" strings in the chat cards.